### PR TITLE
Auto-signing with signingConfigs

### DIFF
--- a/.github/workflows/github-actions-android.yml
+++ b/.github/workflows/github-actions-android.yml
@@ -46,7 +46,7 @@ jobs:
           cache: gradle
 
       - name: Build APK
-        run: bash ./gradlew assembleDebug --stacktrace
+        run: ./gradlew assembleDebug --stacktrace
       - name: Upload APK
         uses: actions/upload-artifact@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Keystore files
+/keystore
+*.jks
+*.keystore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,17 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+// Create a variable called keystorePropertiesFile, and initialize it to your keystore.properties file, in the rootProject folder.
+// And load the properties. Now a release bundle could be generated like this: ./gradlew bundleRelease
+def KEYSTORE_PATH = "./keystore/keystore_new/keystore_pkcs12.properties"
+def keystorePropertiesFile = rootProject.file(KEYSTORE_PATH)
+def keystoreProperties = new Properties()
+try {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+} catch (Exception e) {
+    println("WARNING! Keystore files not found! KeystoreProperties couldn't be loaded.\nCheck filepath: $e.message")
+}
+
 android {
     namespace 'com.handysparksoft.valenciabustracker'
     compileSdk 33
@@ -20,10 +31,24 @@ android {
         }
     }
 
+    signingConfigs {
+        config {
+            try {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            } catch (Exception e) {
+                println("WARNING! KeystoreProperties not loaded!")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.config
         }
     }
     compileOptions {


### PR DESCRIPTION
## Description 📋

Allow generating signed bundles or APKs  by running these tasks in Gradle:
- `bundleRelease`
- `assembleRelease`

The output `app-release.aab` or `app-release.apk` will be signed with the upload key.

## Type of change ⚙️

- [ ] New feature
- [ ] Bug fix
- [X] Architecture / CI
- [X] Documentation

