### PR TITLE
Fix Github Actions APK job

### DIFF
--- a/.github/workflows/github-actions-android.yml
+++ b/.github/workflows/github-actions-android.yml
@@ -30,10 +30,9 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
-
-  run_if_label_matches:
-    if: github.event.label.name == 'apk'
+  apk:
     name: Generate APK
+    if: contains(github.event.pull_request.labels.*.name, 'apk')
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description 📋

Fix the **APK** job in Github Actions. The `contains` condition did the trick and also the order is important, first `name` and next to it the `if` condition.
```
apk:
    name: Generate APK
    if: contains(github.event.pull_request.labels.*.name, 'apk')
    needs: build
```

## Type of change ⚙️

- [ ] New feature
- [X] Bug fix
- [ ] Architecture
- [ ] Documentation
