### PR TITLE
Foreground Service that will show schedule changes in a given Bus Stop

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".ValenciaBusTrackerApplication"
         android:allowBackup="true"
@@ -17,7 +21,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.ValenciaBusTracker">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -29,6 +33,13 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
-    </application>
 
+        <service
+            android:name=".BusStopTrackerService"
+            android:enabled="true"
+            android:exported="false"
+            android:label=""
+            android:roundIcon="@drawable/ic_launcher_foreground"
+            android:stopWithTask="false" />
+    </application>
 </manifest>

--- a/app/src/main/java/com/handysparksoft/valenciabustracker/BusStopTrackerService.kt
+++ b/app/src/main/java/com/handysparksoft/valenciabustracker/BusStopTrackerService.kt
@@ -1,0 +1,203 @@
+package com.handysparksoft.valenciabustracker
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import timber.log.Timber
+import java.io.Serializable
+
+class BusStopTrackerService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+
+        val action = intent.action
+
+        /** Stop the service if we receive the Stop action.
+         *  START_NOT_STICKY is important here, we don't want the service to be relaunched.
+         */
+        if (action == BusStopTrackerAction.ActionStop.name) {
+            // Stuff to do before stopping the service
+            Timber.d("Action stop")
+            stopService()
+            return START_NOT_STICKY
+        }
+
+        startForegroundServiceWithNotification(this, intent)
+
+        when (action) {
+            BusStopTrackerAction.Action1.name -> {
+                Timber.d("Action 1")
+            }
+            BusStopTrackerAction.Action2.name -> {
+                Timber.d("Action 2")
+            }
+        }
+
+        instance = this
+        return START_STICKY
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun startForegroundServiceWithNotification(context: Context, intent: Intent) {
+        (intent.extras?.get(NOTIFICATION_DATA_ARG) as? NotificationData)?.let { notificationData ->
+            val notification = getNotification(
+                context = this,
+                notificationData = notificationData
+            )
+
+            if (isMyServiceRunning()) {
+                (context.getSystemService(NOTIFICATION_SERVICE) as? NotificationManager)?.notify(
+                    NOTIFICATION_ID,
+                    notification
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        }
+    }
+
+    /**
+     * Remove the foreground notification and stop the service.
+     */
+    private fun stopService() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+        Timber.d("Service stopped")
+    }
+
+    override fun onDestroy() {
+        instance = null
+        super.onDestroy()
+    }
+
+    companion object {
+        const val NOTIFICATION_DATA_ARG = "NotificationData"
+        private const val NOTIFICATION_ID = 1
+        private var instance: BusStopTrackerService? = null
+
+        fun startTheService(context: Context, notificationData: NotificationData, action: BusStopTrackerAction? = null) {
+            val serviceIntent = Intent(context, BusStopTrackerService::class.java)
+            action?.let { serviceIntent.action = action.toString() }
+            serviceIntent.putExtra(NOTIFICATION_DATA_ARG, notificationData)
+            context.startForegroundService(serviceIntent)
+        }
+
+        fun stopTheService(context: Context) {
+            val serviceIntent = Intent(context, BusStopTrackerService::class.java)
+            serviceIntent.action = BusStopTrackerAction.ActionStop.toString()
+            context.startService(serviceIntent)
+        }
+
+        private fun getNotification(
+            context: Context,
+            notificationData: NotificationData,
+            isOngoing: Boolean = true,
+            isOnlyAlertOnce: Boolean = true
+        ): Notification? {
+            val notificationChannel = BusTrackerNotificationChannel(
+                name = "Bus Stop Tracker",
+                description = "Schedule changes tracker",
+                importance = NotificationManager.IMPORTANCE_HIGH
+            )()
+
+            val notificationManager = context.getSystemService(NOTIFICATION_SERVICE) as? NotificationManager
+            notificationManager?.let {
+                Timber.d("Notifications are enabled: ${it.areNotificationsEnabled()}")
+
+                it.createNotificationChannel(notificationChannel)
+
+                val notificationBuilder = NotificationCompat.Builder(context, notificationChannel.id)
+                val notificationIntent = Intent(context, MainActivity::class.java)
+                val pendingIntent = PendingIntent.getActivity(
+                    context,
+                    0,
+                    notificationIntent,
+                    PendingIntent.FLAG_IMMUTABLE
+                )
+
+                return notificationBuilder
+                    .setOngoing(isOngoing)
+                    .setOnlyAlertOnce(isOnlyAlertOnce)
+                    .setContentTitle(notificationData.contentTitle)
+                    .setContentText(notificationData.contentText)
+                    .setSubText(notificationData.subText)
+                    .setSmallIcon(R.drawable.ic_launcher_foreground)
+                    // .setProgress(100, 50, false)
+                    .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                    .setContentIntent(pendingIntent)
+                    .setStyle(
+                        NotificationCompat.BigTextStyle().bigText(
+                            notificationData.listItems.map { it }.joinToString(separator = "\n") { it }
+                        )
+                    )
+                    .addAction(getAction1(context))
+                    .addAction(getAction2(context))
+                    .addAction(getActionStop(context))
+                    .build()
+            }
+            return null
+        }
+
+        private fun isMyServiceRunning() = instance != null
+
+        @Suppress("UnusedPrivateMember")
+        private fun isNotificationAlreadyInPlace(context: Context): Boolean {
+            (context.getSystemService(NOTIFICATION_SERVICE) as? NotificationManager)?.let { notificationManager ->
+                return notificationManager.activeNotifications.any { it.id == NOTIFICATION_ID }
+            }
+            return false
+        }
+
+        /**
+         * Notification Actions
+         */
+        private fun getAction1(context: Context) = getNotificationAction(
+            context = context,
+            action = BusStopTrackerAction.Action1,
+            text = context.getString(R.string.foreground_notification_action_1)
+        )
+
+        private fun getAction2(context: Context) = getNotificationAction(
+            context = context,
+            action = BusStopTrackerAction.Action2,
+            text = context.getString(R.string.foreground_notification_action_2)
+        )
+
+        private fun getActionStop(context: Context) = getNotificationAction(
+            context = context,
+            action = BusStopTrackerAction.ActionStop,
+            text = context.getString(R.string.foreground_notification_action_stop)
+        )
+
+        private fun getNotificationAction(
+            context: Context,
+            action: BusStopTrackerAction,
+            text: String,
+            icon: Int = 0
+        ): NotificationCompat.Action {
+            val intent = Intent(context, BusStopTrackerService::class.java)
+            intent.action = action.toString()
+            val pendingIntent = PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+            return NotificationCompat.Action(icon, text, pendingIntent)
+        }
+    }
+}
+
+enum class BusStopTrackerAction { Action1, Action2, ActionStop }
+
+data class NotificationData(
+    val contentTitle: String,
+    val contentText: String,
+    val subText: String,
+    val listItems: List<String> = emptyList()
+) : Serializable

--- a/app/src/main/java/com/handysparksoft/valenciabustracker/BusTrackerNotificationChannel.kt
+++ b/app/src/main/java/com/handysparksoft/valenciabustracker/BusTrackerNotificationChannel.kt
@@ -1,0 +1,25 @@
+package com.handysparksoft.valenciabustracker
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+
+class BusTrackerNotificationChannel(
+    private val name: String,
+    private val description: String? = null,
+    private val importance: Int = NotificationManager.IMPORTANCE_DEFAULT
+) {
+    private val notificationChannelId = name.trim()
+    private val notificationChannelName = name
+
+    private fun getNotificationChannel(): NotificationChannel {
+        val notificationChannel = NotificationChannel(
+            notificationChannelId,
+            notificationChannelName,
+            importance
+        )
+        notificationChannel.description = description
+        return notificationChannel
+    }
+
+    operator fun invoke() = getNotificationChannel()
+}

--- a/app/src/main/java/com/handysparksoft/valenciabustracker/MainActivity.kt
+++ b/app/src/main/java/com/handysparksoft/valenciabustracker/MainActivity.kt
@@ -5,11 +5,15 @@ import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.play.core.review.ReviewManagerFactory
@@ -27,7 +31,21 @@ class MainActivity : ComponentActivity() {
             ValenciaBusTrackerTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    Greeting("Android")
+                    Column(
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        Greeting("Android")
+                        Button(onClick = {
+                            BusStopTrackerService.startTheService(
+                                this@MainActivity,
+                                NotificationData("Title", "Text", "Subtext")
+                            )
+                        }) {
+                            Text(text = "Start foreground service")
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">Valencia Bus Tracker</string>
+
+    <string name="foreground_notification_action_1">Acción 1</string>
+    <string name="foreground_notification_action_2">Acción 2</string>
+    <string name="foreground_notification_action_stop">Apagar</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Valencia Bus Tracker</string>
+
+    <string name="foreground_notification_action_1">Action 1</string>
+    <string name="foreground_notification_action_2">Action 2</string>
+    <string name="foreground_notification_action_stop">Turn off</string>
 </resources>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -654,7 +654,7 @@ style:
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:
-    active: true
+    active: false
   SpacingBetweenPackageAndImports:
     active: false
   ThrowsCount:
@@ -748,7 +748,7 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
+    maxLineLength: 124
   BlockCommentInitialStarAlignment:
     active: false
     autoCorrect: true
@@ -785,7 +785,7 @@ formatting:
     autoCorrect: true
     forceMultilineWhenParameterCountGreaterOrEqualThan: 2147483647
     functionBodyExpressionWrapping: 'default'
-    maxLineLength: 120
+    maxLineLength: 124
     indentSize: 4
   FunctionStartOfBodySpacing:
     active: false
@@ -807,7 +807,7 @@ formatting:
     indentSize: 4
   MaximumLineLength:
     active: true
-    maxLineLength: 120
+    maxLineLength: 124
     ignoreBackTickedIdentifier: false
   ModifierListSpacing:
     active: false
@@ -869,7 +869,7 @@ formatting:
   ParameterListWrapping:
     active: true
     autoCorrect: true
-    maxLineLength: 120
+    maxLineLength: 124
   SpacingAroundAngleBrackets:
     active: true
     autoCorrect: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Here you can find the documentation of the main stack used in this project.
 
 [Ktlint] is an open source library from Pinterest which have several [integrations/wrappers]. This project make use of the [jlleitschuh/ktlint-gradle] Gradle plugin which automatically creates check and format tasks for project Kotlin sources. It supports different kotlin plugins and Gradle build caching.
 
+<details>
+<summary>Show ktlint gradle configuration</summary>
 
 Gradle _root/build.gradle_ configuration:
 
@@ -28,6 +30,7 @@ allprojects {
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 }
 ```
+</details>
 
 Once the project is synced then check these ktlint gradle tasks are available:
 
@@ -45,6 +48,8 @@ Check [Detekt docs] for more info. Some interesting entries are:
 - [Configuration for Compose]
 - [Complexity rules]
 
+<details>
+<summary>Show detekt gradle configuration</summary>
 
 Gradle _root/build.gradle_ configuration:
 
@@ -69,6 +74,7 @@ allprojects {
     }
 }
 ```
+</details>
 
 Once the project is synced then check these detekt gradle tasks are available:
 
@@ -291,6 +297,15 @@ class ValenciaBusTrackerApplication : Application() {
 ```
 </details>
 
+## Foreground services
+> [Foreground services] perform operations that are noticeable to the user. A status bar notification is shown, so that users are actively aware that your app is performing a task in the foreground and is consuming system resources.
+
+Apps that target Android 9 (API level 28) or higher and use foreground services must request the `FOREGROUND_SERVICE` permission in the Android Manifest.
+
+Apps that target Android 13 (API level 33) have notifications turned off by default so they need to be enabled either manually or by the new [notification runtime permissions]. Also, the app must request the `POST_NOTIFICATIONS` permission in the Android Manifest.
+
+
+
 [//]: # (Document links)
 
 [Ktlint]: <https://pinterest.github.io/ktlint/>
@@ -303,3 +318,5 @@ class ValenciaBusTrackerApplication : Application() {
 [GitHub Actions]: <https://github.com/features/actions>
 [signingConfigs]: <https://developer.android.com/studio/publish/app-signing#secure-shared-keystore>
 [Timber]: <https://github.com/JakeWharton/timber>
+[Foreground services]: <https://developer.android.com/guide/components/foreground-services>
+[notification runtime permissions]: <https://developer.android.com/develop/ui/views/notifications/notification-permission>


### PR DESCRIPTION
## Description 📋

- Add the **Foreground Service** that will show in a notification the schedule changes for a given Bus Stop.
- Also add `android:launchMode="singleTask"` in AndroidManifest in order to avoid activity duplication when clicking the notification and redirecting to MainActivity.

> A Foreground Service performs operations that are noticeable to the user. A status bar notification is shown so that users are actively aware that your app is performing a task in the foreground and is consuming system resources.

See: 

 - [Foreground services](https://developer.android.com/guide/components/foreground-services)
 - [Notification runtime permission](https://developer.android.com/develop/ui/views/notifications/notification-permission)

## Type of change ⚙️

- [X] New feature
- [ ] Bug fix
- [ ] Architecture
- [ ] Documentation

## Screenshots 📸
<img src="https://user-images.githubusercontent.com/11421976/194600821-9ec53794-b9e8-444b-811a-738af14f22b3.png" width=300px>

