### PR TITLE
Start foreground service on Boot Completed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".ValenciaBusTrackerApplication"
@@ -41,5 +42,16 @@
             android:label=""
             android:roundIcon="@drawable/ic_launcher_foreground"
             android:stopWithTask="false" />
+
+        <receiver
+            android:name=".BusTrackerBootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.USER_PRESENT" />
+                <action android:name="android.intent.action.REBOOT" />
+            </intent-filter>
+        </receiver>
     </application>
+
 </manifest>

--- a/app/src/main/java/com/handysparksoft/valenciabustracker/BusTrackerBootReceiver.kt
+++ b/app/src/main/java/com/handysparksoft/valenciabustracker/BusTrackerBootReceiver.kt
@@ -1,0 +1,22 @@
+package com.handysparksoft.valenciabustracker
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+class BusTrackerBootReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        val action = intent?.action
+        BusStopTrackerService.startTheService(
+            context = context,
+            notificationData = NotificationData(
+                contentTitle = context.getString(R.string.app_name),
+                contentText = context.getString(R.string.foreground_notification_on_boot_info),
+                subText = context.getString(R.string.foreground_notification_on_boot_completed)
+            )
+        )
+        Timber.d("BroadcastReceiver triggered by $action")
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,4 +4,6 @@
     <string name="foreground_notification_action_1">Acción 1</string>
     <string name="foreground_notification_action_2">Acción 2</string>
     <string name="foreground_notification_action_stop">Apagar</string>
+    <string name="foreground_notification_on_boot_completed">Boot completado</string>
+    <string name="foreground_notification_on_boot_info">Esto es un ejemplo de funcionalidad \"on boot completed\" broadcast receiver. Por favor, remplázalo con tu propia funcionalidad.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="foreground_notification_action_1">Action 1</string>
     <string name="foreground_notification_action_2">Action 2</string>
     <string name="foreground_notification_action_stop">Turn off</string>
+    <string name="foreground_notification_on_boot_completed">Boot completed</string>
+    <string name="foreground_notification_on_boot_info">This is a sample \"on boot completed\" broadcast receiver feature. Please replace with your own requirements.</string>
 </resources>

--- a/docs/README.md
+++ b/docs/README.md
@@ -304,6 +304,75 @@ Apps that target Android 9 (API level 28) or higher and use foreground services 
 
 Apps that target Android 13 (API level 33) have notifications turned off by default so they need to be enabled either manually or by the new [notification runtime permissions]. Also, the app must request the `POST_NOTIFICATIONS` permission in the Android Manifest.
 
+### Start foreground service on Boot Completed
+
+If it's needed to start the foreground service after a system reboot this can be achieved with a Broadcast Receiver listening to `BOOT_COMPLETED` intent.
+
+<details>
+<summary>Show receiver configuration</summary>
+
+_AndroidManifest_ configuration:
+
+```
+<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+...
+<application>
+        ...
+        <receiver
+            android:name=".BusTrackerBootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.USER_PRESENT" />
+                <action android:name="android.intent.action.REBOOT" />
+            </intent-filter>
+        </receiver>
+</application>        
+        
+```
+
+_BusTrackerBootReceiver_ class:
+
+```
+class BusTrackerBootReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        val action = intent?.action
+        BusStopTrackerService.startTheService(
+            context = context,
+            notificationData = NotificationData(
+                contentTitle = context.getString(R.string.app_name),
+                contentText = context.getString(R.string.foreground_notification_on_boot_info),
+                subText = context.getString(R.string.foreground_notification_on_boot_completed)
+            )
+        )
+        Timber.d("BroadcastReceiver triggered by $action")
+    }
+}
+```
+
+**Note:** If you want to test the functionality you could do it like so:
+
+1. Add a "fake" intent action in the manifest along with the boot ones:
+
+
+```
+            <intent-filter>
+                <action android:name="com.handysparksoft.valenciabustracker.action.TEST" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.USER_PRESENT" />
+                <action android:name="android.intent.action.REBOOT" />
+            </intent-filter>
+
+```
+
+2. Broadcast the action via **adb tool**
+
+```
+adb shell am broadcast -a com.handysparksoft.valenciabustracker.action.TEST -p com.handysparksoft.valenciabustracker
+```
+
+        
 
 
 [//]: # (Document links)


### PR DESCRIPTION
## Description 📋

Foreground Service will be started "On Boot Completed" event. This feature requires `RECEIVE_BOOT_COMPLETED` permission in AndroidManifest. 


## Type of change ⚙️

- [X] New feature
- [ ] Bug fix
- [ ] Architecture
- [X] Documentation

## Screenshots 📸

<img src="https://user-images.githubusercontent.com/11421976/194613477-a2b26196-8a10-4aad-88e8-a4f0c52bfe91.png" width=300px>
