### PR TITLE
Show notifications in Wearables (Wear Os)

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,6 +4,7 @@
     <string name="foreground_notification_action_1">Acción 1</string>
     <string name="foreground_notification_action_2">Acción 2</string>
     <string name="foreground_notification_action_stop">Apagar</string>
+    <string name="foreground_notification_action_wear_refresh">Refrescar</string>
     <string name="foreground_notification_content_title">Título</string>
     <string name="foreground_notification_content_text">Texto</string>
     <string name="foreground_notification_subtext">Subtexto</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="foreground_notification_action_1">Action 1</string>
     <string name="foreground_notification_action_2">Action 2</string>
     <string name="foreground_notification_action_stop">Turn off</string>
+    <string name="foreground_notification_action_wear_refresh">Refresh</string>
     <string name="foreground_notification_content_title">Title</string>
     <string name="foreground_notification_content_text">Text</string>
     <string name="foreground_notification_subtext">Subtext</string>


### PR DESCRIPTION
Ongoing notification are not showing up in wearables so what we have done is to show 2 notifications one with isOngoing and one without it, then we put them in the same group for showing them in the same group and set the alarm only for the the summary which is the one that isOngoing.

## Description 📋

Show Wearables Notifications. (App was already showing the foreground notification but this one was not being forwarded to wearable since ongoing notification are not shown in them)

Detailed explanation: Ongoing notifications are not showing up in wearables so what we have done is to show 2 notifications one with isOngoing and one without it, then we put them in the same **group** for showing them in the same group and set the **alarm** only for the the **summary** which is the one that isOngoing.

See: 

 - [Wear Os Notifications official documentation](https://developer.android.com/training/wearables/notifications)


## Type of change ⚙️

- [ ] New feature
- [ ] Bug fix
- [X] Architecture
- [ ] Documentation

