### PR TITLE
Compose Bill of Materials (BOM)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
     implementation "com.jakewharton.timber:timber:$timber_version"
 
-    implementation "com.google.firebase:firebase-crashlytics-ktx:18.3.0"
+    implementation "com.google.firebase:firebase-crashlytics-ktx:18.3.1"
     implementation "com.google.firebase:firebase-analytics-ktx:21.2.0"
 
     implementation "com.google.android.gms:play-services-ads:21.3.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,12 +74,13 @@ android {
 }
 
 dependencies {
+    implementation platform("androidx.compose:compose-bom:2022.10.00")
 
     implementation "androidx.core:core-ktx:$androidx_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidx_lifecycle"
     implementation "androidx.activity:activity-compose:$activity_compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-tooling-preview"
     implementation "androidx.compose.material3:material3:$material3_version"
 
     implementation "com.google.android.play:core:$google_play_core_version"
@@ -95,7 +96,7 @@ dependencies {
     testImplementation "junit:junit:$test_junit_version"
     androidTestImplementation "androidx.test.ext:junit:$test_ext_junit_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$test_espresso_version"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,17 +2,17 @@ buildscript {
     ext {
         compose_version = "1.3.0-rc01"
 
-        android_application_plugin_version = "7.3.0"
-        android_library_plugin_version = "7.3.0"
+        android_application_plugin_version = "7.3.1"
+        android_library_plugin_version = "7.3.1"
 
-        activity_compose_version = "1.6.0"
+        activity_compose_version = "1.6.1"
         androidx_version = "1.9.0"
         androidx_lifecycle = "2.5.1"
 
         kotlin_version = "1.7.10"
         ktlint_version = "11.0.0"
         detekt_version = "1.22.0-RC1"
-        material3_version = "1.0.0-rc01"
+        material3_version = "1.1.0-alpha01"
         google_play_core_version = "1.10.3"
         google_play_core_ktx_version = "1.8.1"
         timber_version = "5.0.1"

--- a/docs/README.md
+++ b/docs/README.md
@@ -480,6 +480,29 @@ dependencies {
 
 For next steps check the [Get Started Guide with Crashlytics] documentation to learn more about it.
 
+## Compose Bill of Materials (BOM)
+
+> A [BOM] is a Maven module that declares a set of libraries with their versions. It will greatly simplify the way you define Compose library versions in your Gradle dependencies block, especially now that Google moved the various Jetpack Compose libraries to independent versioning schemes.
+
+```
+dependencies {
+    // Import the Compose BOM
+    implementation platform('androidx.compose:compose-bom:2022.10.00')
+    
+    // Declare dependencies for the desired Compose libraries without versions
+    implementation 'androidx.compose.foundation:foundation'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    ...
+}
+``` 
+
+Instead of defining each version separately, which can become cumbersome and prone to errors when library versions start to differ, you now only need to define one BOM version and all Compose library versions will be extracted from that. Google will publish a new version of the BOM every time a Compose artifact has a new **stable release**, so moving from stable release to stable release is going to be much simpler.
+
+Note that you can still choose to define your dependencies using hard-coded versions. The BOM is added as a useful way to simplify dependencies and make upgrades easier.
+
+To find out which Compose library versions are mapped to a specific BOM version, check out the [BOM to library version mapping].
+
+
 ## AdMob Ads
 
 > Integrating the Google Mobile Ads SDK into an app is the first step toward displaying ads and earning revenue. Once you've integrated the SDK, you can choose an ad format (such as native or rewarded video) and follow the steps to implement it. Check the quick [AdMob Quick Start Guide] for more info.
@@ -507,3 +530,5 @@ These are the different types of ads you can add to your app:
 [Get Started Guide with Crashlytics]: <https://firebase.google.com/docs/crashlytics/get-started?hl=en&platform=android>
 [Firebase Console]: <https://console.firebase.google.com/>
 [AdMob Quick Start Guide]: <https://developers.google.com/admob/android/quick-start>
+[BOM]: <https://developer.android.com/jetpack/compose/setup#using-the-bom>
+[BOM to library version mapping]: <https://developer.android.com/jetpack/compose/setup#bom-version-mapping>


### PR DESCRIPTION
## Description 📋

Use of **Compose Bill of Materials** (BOM) in the project for easier Compose dependency management. With BOM you only need to add one single version line like this:

```
implementation platform("androidx.compose:compose-bom:2022.10.00")
```

and the there is no need to specify the versions in Compose dependencies because latest stable ones will be used. Like this:

```
implementation platform("androidx.compose:compose-bom:2022.10.00")
...
implementation "androidx.compose.ui:ui"
implementation "androidx.compose.ui:ui-tooling-preview"
androidTestImplementation "androidx.compose.ui:ui-test-junit4"
debugImplementation "androidx.compose.ui:ui-tooling"
debugImplementation "androidx.compose.ui:ui-test-manifest"
``` 

See:

 - [BOM](https://developer.android.com/jetpack/compose/setup#using-the-bom)

## Type of change ⚙️

- [ ] New feature
- [ ] Bug fix
- [X] Architecture
- [X] Documentation

